### PR TITLE
rn perm links

### DIFF
--- a/_whatsnew/2025-05-12.adoc
+++ b/_whatsnew/2025-05-12.adoc
@@ -16,9 +16,9 @@ Upon failover, BlueXP disaster recovery replaces the Network portion of the orig
 
 In summary, the host address stays the same, while the network address is replaced with whatever is configured in the site subnet mapping. This enables you to manage IP address reassignment upon failover more easily, especially if you have hundreds of networks and thousands of VMs to manage. 
 
-For details about including subnet mapping in your sites, see  link:../use/sites-add.html[Add vCenter server sites].
+//For details about including subnet mapping in your sites, see  link:../use/sites-add.html[Add vCenter server sites].
 
-//For details about including subnet mapping in your sites, refer to https://docs.netapp.com/us-en/bluexp-disaster-recovery/use/sites-add.html[Add vCenter server sites].
+For details about including subnet mapping in your sites, refer to https://docs.netapp.com/us-en/bluexp-disaster-recovery/use/sites-add.html[Add vCenter server sites].
 
 === Skip protection 
 
@@ -30,9 +30,9 @@ When initiating a failover, you can now choose a *Skip protection* option. With 
 
 After the original source site is back online, you can establish reverse protection by selecting *Protect resources* from the Replication plan Actions menu. This attempts to create a reverse replication relationship for each volume in the plan. You can run this job repeatedly until protection is restored. When protection is restored, you can initiate a failback in the usual way.
 
-For details about skipping protection, see  link:../use/failover.html[Fail over applications to a remote site].
+//For details about skipping protection, see  link:../use/failover.html[Fail over applications to a remote site].
 
-//For details skipping protection, refer to https://docs.netapp.com/us-en/bluexp-disaster-recovery/use/failover.html[Fail ovre applications to a remote site].
+For details skipping protection, refer to https://docs.netapp.com/us-en/bluexp-disaster-recovery/use/failover.html[Fail ovre applications to a remote site].
 
 === SnapMirror schedule updates in the replication plan
 
@@ -44,6 +44,6 @@ When selected, BlueXP disaster recovery does not configure a backup schedule. Ho
 
 After this is configured, the service doesn't take any regularly scheduled snapshots, but instead relies on the external entity to take and update those snapshots.
 
-For details using external snapshot solutions in the replication plan, see  link:../use/drplan-create.html[Create a replication plan].
+//For details using external snapshot solutions in the replication plan, see  link:../use/drplan-create.html[Create a replication plan].
 
-//For details skipping protection, refer to https://docs.netapp.com/us-en/bluexp-disaster-recovery/use/drplan-create.html[Create a replication plan].
+For details skipping protection, refer to https://docs.netapp.com/us-en/bluexp-disaster-recovery/use/drplan-create.html[Create a replication plan].

--- a/release-notes/dr-whats-new.adoc
+++ b/release-notes/dr-whats-new.adoc
@@ -15,7 +15,7 @@ Learn what’s new in BlueXP disaster recovery.
 
 //tag::whats-new[]
 
-== 12 May 2025 
+== 13 May 2025 
 Version 4.2.3
 
 include::../_whatsnew/2025-05-12.adoc[] 


### PR DESCRIPTION
This pull request includes updates to the documentation for BlueXP disaster recovery, primarily focusing on improving clarity and ensuring accurate referencing of external resources. The most significant changes involve corrections to URLs and adjustments to publication dates.

### Documentation Updates:

* [`_whatsnew/2025-05-12.adoc`](diffhunk://#diff-da4139c85169a83107a086d613d28a527519fc218e4528d40fcbb1beb09ca330L19-R21): Corrected and standardized the references to external documentation links by replacing commented-out lines with active links. This ensures that users can directly access the relevant resources for subnet mapping, skipping protection, and external snapshot solutions. [[1]](diffhunk://#diff-da4139c85169a83107a086d613d28a527519fc218e4528d40fcbb1beb09ca330L19-R21) [[2]](diffhunk://#diff-da4139c85169a83107a086d613d28a527519fc218e4528d40fcbb1beb09ca330L33-R35) [[3]](diffhunk://#diff-da4139c85169a83107a086d613d28a527519fc218e4528d40fcbb1beb09ca330L47-R49)

### Metadata Updates:

* [`release-notes/dr-whats-new.adoc`](diffhunk://#diff-0799112957ee3db34e4e9c9e17814c054717b9640eee9b85555bfc6994c2f205L18-R18): Updated the release date from "12 May 2025" to "13 May 2025" for version 4.2.3, ensuring consistency in release note timelines.